### PR TITLE
Some further fixes.

### DIFF
--- a/ConfigGUI/ConfigGUI.csproj
+++ b/ConfigGUI/ConfigGUI.csproj
@@ -57,14 +57,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="fCraft, Version=0.6.1.7, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\fCraft.dll</HintPath>
-    </Reference>
-    <Reference Include="fCraftGUI, Version=0.6.1.7, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\fCraftGUI.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -215,6 +207,16 @@
   <ItemGroup>
     <Content Include="LegendCraftLogoIcon.ico" />
     <Content Include="LegendCraftLogoText.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\fCraftGUI\fCraftGUI.csproj">
+      <Project>{AFAEE6CC-8B4F-40CD-9623-7FFDC8E52222}</Project>
+      <Name>fCraftGUI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\fCraft\fCraft.csproj">
+      <Project>{7FBE7809-6F77-415C-ABEB-A3F627E817B0}</Project>
+      <Name>fCraft</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ServerCLI/ServerCLI.csproj
+++ b/ServerCLI/ServerCLI.csproj
@@ -55,14 +55,6 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="fCraft, Version=0.6.1.7, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\fCraft.dll</HintPath>
-    </Reference>
-    <Reference Include="fCraftGUI, Version=0.6.1.7, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\fCraftGUI.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -92,6 +84,16 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="ServerCLI.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\fCraftGUI\fCraftGUI.csproj">
+      <Project>{AFAEE6CC-8B4F-40CD-9623-7FFDC8E52222}</Project>
+      <Name>fCraftGUI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\fCraft\fCraft.csproj">
+      <Project>{7FBE7809-6F77-415C-ABEB-A3F627E817B0}</Project>
+      <Name>fCraft</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ServerGUI/ServerGUI.csproj
+++ b/ServerGUI/ServerGUI.csproj
@@ -58,14 +58,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="fCraft, Version=0.6.1.7, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\fCraft.dll</HintPath>
-    </Reference>
-    <Reference Include="fCraftGUI, Version=0.6.1.7, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Debug\fCraftGUI.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -126,6 +118,16 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="LegendCraftLogoIcon.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\fCraftGUI\fCraftGUI.csproj">
+      <Project>{AFAEE6CC-8B4F-40CD-9623-7FFDC8E52222}</Project>
+      <Name>fCraftGUI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\fCraft\fCraft.csproj">
+      <Project>{7FBE7809-6F77-415C-ABEB-A3F627E817B0}</Project>
+      <Name>fCraft</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/fCraft/Commands/BuildingCommands.cs
+++ b/fCraft/Commands/BuildingCommands.cs
@@ -578,24 +578,68 @@ THE SOFTWARE.*/
             Handler = UndoAllHandler
         };
 
-        public static void UndoAllHandler(Player player, Command cmd)
-        {
-            string targetName = cmd.Next();
-            if (targetName == null)
-            {
-                CdUndoAll.PrintUsage(player);
+        public static void UndoAllHandler(Player player, Command cmd) {
+            // check if command's being called by a worldless player (e.g. console)
+            World playerWorld = player.World;
+            if (playerWorld == null) PlayerOpException.ThrowNoWorld(player);
+
+            // ensure that BlockDB is enabled
+            if (!BlockDB.IsEnabledGlobally) {
+                player.Message("&WUndoAll: BlockDB is disabled on this server."); return;
             }
-            PlayerInfo target = PlayerDB.FindPlayerInfoOrPrintMatches(player, targetName);
-            if (target == null)
-            {
-                player.MessageNoPlayer(targetName);
+            if (!playerWorld.BlockDB.IsEnabled) {
+                player.Message("&WUndoAll: BlockDB is disabled in this world."); return;
+            }  
+            
+            string name = cmd.Next();
+            if (name == null) {
+                CdUndoAll.PrintUsage(player); return;
+            }
+            PlayerInfo target = PlayerDB.FindPlayerInfoOrPrintMatches(player, name);
+            if (target == null) {
+                player.MessageNoPlayer(name); return;
+            }
+            if( !player.Can(Permission.UndoOthersActions, target.Rank)) {
+                player.Message("&WUndoAll: You may only undo actions of players ranked {0}&S or lower.",
+                               player.Info.Rank.GetLimit(Permission.UndoOthersActions).ClassyName);
+                player.Message("Player {0}&S is ranked {1}", target.ClassyName, target.Rank.ClassyName);
                 return;
             }
-            UndoAllHandler(player, new Command("/undoall " + target.Name));
+            
+            BlockDBUndoArgs args = new BlockDBUndoArgs {
+                Player = player,
+                CountLimit = 100000,
+                Area = player.WorldMap.Bounds,
+                World = playerWorld,
+                Targets = new PlayerInfo[] { target },
+            }; 
+            Scheduler.NewBackgroundTask(UndoAllLookup)
+                     .RunOnce(args, TimeSpan.Zero);
         }
         
-        
-        
+        static void UndoAllLookup(SchedulerTask task) {
+            BlockDBUndoArgs args = (BlockDBUndoArgs)task.UserState;
+            const string cmdName = "UndoPlayer";
+            Vector3I[] coords = new Vector3I[0];
+            args.Entries = args.World.BlockDB.Lookup(args.CountLimit, args.Targets, args.Not);
+
+            // Produce a brief param description for BlockDBDrawOperation
+            string description = String.Format("{0} by {1}", args.CountLimit,
+                                                 args.Targets.JoinToString(p => p.Name));
+
+            // start undoing (using DrawOperation infrastructure)
+            var op = new BlockDBDrawOperation(args.Player, cmdName, description, coords.Length);
+            op.Prepare(coords, args.Entries);
+
+            // log operation
+            string targetList = targetList = args.Targets.JoinToClassyString();
+            Logger.Log(LogType.UserActivity,
+                        "{0}: Player {1} will undo {2} changes (limit of {3}) by {4} on world {5}",
+                        cmdName, args.Player.Name, args.Entries.Length,
+                        args.CountLimit.ToString(NumberFormatInfo.InvariantInfo),
+                        targetList, args.World.Name);
+            op.Begin();
+        }
         
         static readonly CommandDescriptor CdAbortAll = new CommandDescriptor 
     	{
@@ -2656,7 +2700,6 @@ THE SOFTWARE.*/
             Scheduler.NewBackgroundTask(UndoPlayerLookup)
                      .RunOnce(args, TimeSpan.Zero);
         }
-
 
         // Looks up the changes in BlockDB and prints a confirmation prompt. Runs on a background thread.
         static void UndoPlayerLookup(SchedulerTask task)

--- a/fCraft/MapConversion/MapD3.cs
+++ b/fCraft/MapConversion/MapD3.cs
@@ -200,7 +200,7 @@ namespace fCraft.MapConversion {
                     bs.Write( IPAddress.NetworkToHostOrder( mapToSave.Height ) );
 
                     // Write the map data
-                    bs.Write( mapToSave.Blocks, 0, mapToSave.Blocks.Length );
+                    MapUtility.WriteAll( mapToSave.Blocks, bs );
 
                     bs.Close();
                     return true;

--- a/fCraft/MapConversion/MapFCMv3.cs
+++ b/fCraft/MapConversion/MapFCMv3.cs
@@ -227,7 +227,8 @@ namespace fCraft.MapConversion {
                         // write metadata
                         metaCount = WriteMetadata( bs, mapToSave );
                         offset = mapStream.Position; // inaccurate, but who cares
-                        bs.Write( blocksCache, 0, blocksCache.Length );
+                        bs.Flush();
+                        MapUtility.WriteAll( blocksCache, bs );
                         compressedLength = (int)(mapStream.Position - offset);
                     }
                 }

--- a/fCraft/MapConversion/MapJTE.cs
+++ b/fCraft/MapConversion/MapJTE.cs
@@ -156,7 +156,7 @@ namespace fCraft.MapConversion {
                     bs.Write( IPAddress.NetworkToHostOrder( mapToSave.Height ) );
 
                     // Write the map data
-                    bs.Write( mapToSave.Blocks, 0, mapToSave.Blocks.Length );
+                    MapUtility.WriteAll( mapToSave.Blocks, bs );
                 }
                 return true;
             }

--- a/fCraft/MapConversion/MapMCSharp.cs
+++ b/fCraft/MapConversion/MapMCSharp.cs
@@ -269,7 +269,7 @@ namespace fCraft.MapConversion {
                     bs.Write( (byte)0 );
 
                     // Write the map data
-                    bs.Write( mapToSave.Blocks, 0, mapToSave.Blocks.Length );
+                    MapUtility.WriteAll( mapToSave.Blocks, bs );
 
                     bs.Close();
                 }

--- a/fCraft/MapConversion/MapMinerCPP.cs
+++ b/fCraft/MapConversion/MapMinerCPP.cs
@@ -144,7 +144,7 @@ namespace fCraft.MapConversion {
                     bs.Write( IPAddress.HostToNetworkOrder( mapToSave.Blocks.Length ) );
 
                     // Write out the map data
-                    bs.Write( mapToSave.Blocks );
+                    MapUtility.WriteAll( mapToSave.Blocks, bs );
                     return true;
                 }
             }

--- a/fCraft/MapConversion/MapUtility.cs
+++ b/fCraft/MapConversion/MapUtility.cs
@@ -217,5 +217,31 @@ namespace fCraft.MapConversion {
                 bytesLeft -= readPass;
             }
         }
+        
+        // Write at most 256 MiB at a time.
+        const int MaxWriteChunk = 256*1024*1024;
+
+        // Works around an overflow in BufferedStream.Write() that happens on 1 GiB+ writes.
+        internal static void WriteAll([NotNull] byte[] source, [NotNull] Stream destination) {
+            if (source == null) throw new ArgumentNullException("source");
+            if (destination == null) throw new ArgumentNullException("destination");
+            int written = 0;
+            while (written < source.Length) {
+                int toWrite = Math.Min(MaxWriteChunk, source.Length - written);
+                destination.Write(source, written, toWrite);
+                written += toWrite;
+            }
+        }
+        
+        internal static void WriteAll([NotNull] byte[] source, [NotNull] BinaryWriter destination) {
+            if (source == null) throw new ArgumentNullException("source");
+            if (destination == null) throw new ArgumentNullException("destination");
+            int written = 0;
+            while (written < source.Length) {
+                int toWrite = Math.Min(MaxWriteChunk, source.Length - written);
+                destination.Write(source, written, toWrite);
+                written += toWrite;
+            }
+        }
     }
 }

--- a/fCraftGUI/fCraftGUI.csproj
+++ b/fCraftGUI/fCraftGUI.csproj
@@ -57,9 +57,6 @@
     <ApplicationIcon>LegendCraftLogoIcon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="fCraft">
-      <HintPath>..\fCraft\bin\DEBUG_BLOCKDB\fCraft.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -117,6 +114,12 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\fCraft\fCraft.csproj">
+      <Project>{7FBE7809-6F77-415C-ABEB-A3F627E817B0}</Project>
+      <Name>fCraft</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Referencing fCraft/fCraftGui projects, instead of the .dll files, avoids those strange errors when building the project for the first time.

Also fix 1024^3 maps failing to save.